### PR TITLE
Misc

### DIFF
--- a/Doc/QuickStart.md
+++ b/Doc/QuickStart.md
@@ -5,7 +5,18 @@
 
 Be welcome! Here is a hands-on introduction to Active Logic. Let's get started.
 
-This introduction is engine agnostic; if you are using Unity, read the [Unity Quick Start Guide](QuickStart-Unity.md).
+This introduction is engine agnostic. Unity users may prefer the [Unity Quick Start Guide](QuickStart-Unity.md).
+
+## Setting the time
+
+Before evaluating a behaviour tree, set the time:
+
+```
+// Set at game frame start or before invoking your ticker
+SimTime.time = System.DateTime.Now.TotalMilliseconds/1000f;
+```
+
+Active Logic uses [simulated time](Reference/SimTime.md) to evaluate certain decorators, such as intervals and cooldowns.
 
 ## Status expressions and the update loop
 

--- a/Doc/Reference/Constants-and-logging.md
+++ b/Doc/Reference/Constants-and-logging.md
@@ -43,6 +43,23 @@ loop.cont()
 impending.done() // will not compile since 'impending' never succeeds
 ```
 
+## Using `undef()`
+
+If you defer implementing a status function, use `undef`:
+
+```cs
+status Defend() => undef();
+```
+
+Release and optimized builds do not support `undef`; this ensures your product is feature-complete before shipping.
+
+By default `undef` returns the failing status; this may be customized:
+
+```cs
+status Defend() => undef(cont);    // with Active.Raw
+status Defend() => undef(cont());  // with Active.Status
+```
+
 ## Expression wrappers
 
 Via `Active.Raw` or `Active.Status`, use a wrapper to include any expression within a status expression, then return an arbitrary status constant; here is an example:

--- a/Doc/Reference/SimTime.md
+++ b/Doc/Reference/SimTime.md
@@ -1,0 +1,25 @@
+*Sources: SimTime.cs - Last Updated: 2021.07.18*
+
+# SimTime Reference
+
+In order for time-reliant decorators (cooldown, delay, interval, timeout, wait and perhaps others) to work as expected, the time should be correctly set.
+
+- In a video game, usually you want game time; this (ordinarily) is different from real time.
+- When evaluating a simulation, set the time at the beginning of each iteration.
+- For some applications, real time may be just what you need.
+
+## Setting the time
+
+Depending on the intended use case, there's a couple of approaches to setting the time:
+
+1- If all the agents/tickers in your game use the same time, consider setting `SimTime.time` at the beginning of each iteration (or game/physics frame)
+
+2- In less common cases, different agents may each use their own time. For example, in a turn based game, 'tactical time' (round count) may be used to evaluate some agents while other parts of your game may use real time for animation.
+
+**Sim time is not thread safe** - you may use sim time in a multi-threaded environment, provided all agents use the same time, and all threads complete work within the current iteration.
+
+Note: in *Unity*, time defaults to `UnityEngine.Time.time`; you may change this on a stepper basis (see [Steppers](Unity/Steppers.md))
+
+## Fields & Properties
+
+`time` - get/set the current time.

--- a/README.md
+++ b/README.md
@@ -19,25 +19,23 @@ Active Logic seamlessly integrates with C#:
 ```cs
 class Duelist : UTask{
 
-    float health = 100;
-
-    Transform threat => null;
+    float     health = 100;
+    Transform threat;
 
     // BT selectors and sequences via || and &&
-    override public status Step() => Attack() || Defend() || Retreat();
+    override public status Step()
+        => Attack()
+        || Defend()
+        || Retreat();
 
     // Conditionals without 'conditional nodes'
-    status Attack() => threat && health > 25
-        ? Engage(threat) && Cooldown(1.0f)?[ Strike(threat) ]
-        : fail(log && $"No threat, or low hp ({health})");
+    status Attack() => (threat && health > 25) ?
+        Engage(threat) && Cooldown(1.0f)?[ Strike(threat) ]
+      : fail(log && $"No threat, or low hp ({health})");
 
-    // Special statuses (pending, impending, action, ...) are useful
-    // when you know a task will never fail, never succeed or similar.
-    // (optional but type safe!)
-    pending   Defend()                  => + undef();
-    status    Engage(Transform threat)  =>   undef();
-    impending Retreat()                 => - undef();
-    action    Strike(Transform threat)  =>   @void();
+    status Defend() => ...;
+
+    // ...
 
 }
 ```

--- a/Src/Decorators/Cooldown.cs
+++ b/Src/Decorators/Cooldown.cs
@@ -30,11 +30,9 @@ public class Cooldown: Conditional, Conditional.OptionalArguments{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Conditional.Gate? Cooldown(float duration, [Tag] int key = -1)
 	=> store.Decorator<Cooldown>(key, Active.Core.Cooldown.id)[duration];
 }
-#endif
 
 }

--- a/Src/Decorators/Delay.cs
+++ b/Src/Decorators/Delay.cs
@@ -37,12 +37,10 @@ public class Delay: Waiter, Waiter.OptionalArguments{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Waiter.Gate? After(float delay, [Tag] int key = -1)
 	=> store.Decorator<Delay>(key, Active.Core.Delay.id)[delay];
 }
-#endif
 
 }  // Active.Core
 

--- a/Src/Decorators/Drive.cs
+++ b/Src/Decorators/Drive.cs
@@ -67,7 +67,6 @@ public class Drive : AbstractDecorator{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Self.Gate? While(status @in, [Tag] int key = -1)
 	=> store.Decorator<Self>(key, Self.id)[@in, crit: false];
@@ -78,6 +77,5 @@ partial class Task{
     public Self.Gate? Tie(bool @in, [Tag] int key = -1)
     => store.Decorator<Self>(key, Self.id)[@in, crit: true];
 }
-#endif
 
 }

--- a/Src/Decorators/FrameDelay.cs
+++ b/Src/Decorators/FrameDelay.cs
@@ -37,13 +37,11 @@ public class FrameDelay: Waiter, Waiter.OptionalArguments{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Waiter.Gate? AfterFrames(int frames, [Tag] int key = -1)
 	=> store.Decorator<FrameDelay>(key,
                                    Active.Core.FrameDelay.id)[frames];
 }
-#endif
 
 }  // Active.Core
 

--- a/Src/Decorators/InOut.cs
+++ b/Src/Decorators/InOut.cs
@@ -23,11 +23,9 @@ public class InOut : Conditional{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
     public Conditional.Gate? InOut(bool @in, bool @out, [Tag] int key = -1)
     => store.Decorator<InOut>(key, Active.Core.InOut.id)[@in, @out];
 }
-#endif
 
 }

--- a/Src/Decorators/Init.cs
+++ b/Src/Decorators/Init.cs
@@ -56,11 +56,9 @@ public class Init : AbstractDecorator{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
     public Init With([Tag] int key = -1)
     => store.Decorator<Init>(key, Active.Core.Init.id).pass;
 }
-#endif
 
 }  // end-Active.Core

--- a/Src/Decorators/Interval.cs
+++ b/Src/Decorators/Interval.cs
@@ -51,12 +51,10 @@ public class Interval : Waiter, Waiter.OptionalArguments{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Waiter.Gate? Every(float delay, float offset = 0f,
                                            [Tag] int key = -1)
     => store.Decorator<Interval>(key, Active.Core.Interval.id)[delay];
 }
-#endif
 
 }

--- a/Src/Decorators/Latch.cs
+++ b/Src/Decorators/Latch.cs
@@ -23,12 +23,10 @@ public class Latch : Conditional{
 
 }
 
-#if !AL_BEST_PERF
 partial class UTask{
 }partial class Task{
 	public Conditional.Gate? Latch(bool @in, [Tag] int key = -1)
 	=> store.Decorator<Latch>(key, Active.Core.Latch.id)[@in];
 }
-#endif
 
 }

--- a/Src/Decorators/Once.cs
+++ b/Src/Decorators/Once.cs
@@ -62,11 +62,9 @@ public class Once : AbstractDecorator{
 
 }  // Once
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Self.Gate? Once([Tag] int key = -1)
 	=> store.Decorator<Self>(key, Self.id).pass;
 }
-#endif
 
 }

--- a/Src/Decorators/ResetCriterion.cs
+++ b/Src/Decorators/ResetCriterion.cs
@@ -48,12 +48,10 @@ public class ResetCriterion : AbstractDecorator{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
     public ResetCriterion with(object arg, [Tag] int key = -1)
     => store.Decorator<ResetCriterion>(
                   key, Active.Core.ResetCriterion.id).Check(arg, rox);
 }
-#endif
 
 }  // Active.Core

--- a/Src/Decorators/Timeout.cs
+++ b/Src/Decorators/Timeout.cs
@@ -43,13 +43,11 @@ public class Timeout : Conditional, Conditional.OptionalArguments{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public Conditional.Gate? Timeout(float duration,
                                      [Tag] int key = -1)
     => store.Decorator<Timeout>(
                       key, Active.Core.Timeout.id)[duration];
 }
-#endif
 
 }

--- a/Src/Decorators/Wait.cs
+++ b/Src/Decorators/Wait.cs
@@ -35,11 +35,9 @@ public class Wait : AbstractDecorator{
 
 }
 
-#if !AL_BEST_PERF
 partial class Task{
 	public status Wait(float delay, [Tag] int key = -1)
 	=> store.Decorator<Wait>(key, Active.Core.Wait.id)[delay];
 }
-#endif
 
 }  // Active.Core

--- a/Src/Decorators/Wait.cs
+++ b/Src/Decorators/Wait.cs
@@ -22,7 +22,7 @@ public class Wait : AbstractDecorator{
     public static implicit operator status(Wait self)
     => self[self.delay];
 
-    public status this[float duration]{ get{
+    public status this[float delay]{ get{
         Notices.OnEnter(ref frame, this);
         stamp = stamp ?? time;
         var elapsed = time - stamp.Value;

--- a/Src/Details/Stateful/StatusRef.cs
+++ b/Src/Details/Stateful/StatusRef.cs
@@ -38,12 +38,13 @@ public readonly struct StatusRef{
 
      internal static void SetLogData(AbstractDecorator dec,
                               object target, string reason){
+        if(!status.log) return;
         if(checkLogData && staticLogData.HasValue)
             throw new InvOp("Clear log data first");
         staticLogData = new LogData(dec, target, reason);
     }
 
-    // Only for testing; do not use.
+    // Only for unit testing; do not use.
     internal static void ClearLogData() => staticLogData = null;
 
      internal static status ToStatusWithLog(StatusRef? self){
@@ -53,6 +54,7 @@ public readonly struct StatusRef{
                          ι.logData.scope,
                          log && ι.logData.Reason());
          }else{
+             if(!status.log) return hold;
              var scope  = staticLogData.Value.scope;
              var reason = staticLogData.Value.Reason();
              if(scope == null) throw new InvOp("scope is null");

--- a/Src/Details/Stateful/TaskComposites.cs
+++ b/Src/Details/Stateful/TaskComposites.cs
@@ -13,7 +13,6 @@ using S  = System.String;
 namespace Active.Core{
 partial class Task{
 
-    #if !AL_BEST_PERF
     #if !AL_THREAD_SAFE
 
     #if AL_OPTIMIZE
@@ -39,6 +38,5 @@ partial class Task{
     public Comp @do => Comp.current.@do;
 
     #endif  // end !AL_THREAD_SAFE
-    #endif  // end !AL_BEST_PERF
 
 }}

--- a/Src/Details/Stateful/TaskComposites_deprecated.cs
+++ b/Src/Details/Stateful/TaskComposites_deprecated.cs
@@ -5,7 +5,6 @@ using Active.Core.Details;
 namespace Active.Core{
 partial class Task{
 
-    #if !AL_BEST_PERF
     #if AL_THREAD_SAFE
 
       [Obsolete("Use Seq() instead", false)]
@@ -36,6 +35,5 @@ partial class Task{
       => iterator = store.Composite<Selector>(key).iterator;
 
     #endif  // end !AL_THREAD_SAFE
-    #endif  // end !AL_BEST_PERF
 
 }}

--- a/Src/Details/Stateful/TaskDetails.cs
+++ b/Src/Details/Stateful/TaskDetails.cs
@@ -17,9 +17,7 @@ partial class Task{
 
     ReCon _rox;
 
-    #if !AL_BEST_PERF
     internal Store _store;
     Store store => _store ?? (_store = new HashStore());
-    #endif
 
 }}

--- a/Src/SimTime.cs
+++ b/Src/SimTime.cs
@@ -1,0 +1,7 @@
+// Doc/Reference/SimTime.md
+namespace Active.Core{
+public static class SimTime{
+
+    public static float time;
+
+}}

--- a/Src/Stateful/AbstractDecorator.cs
+++ b/Src/Stateful/AbstractDecorator.cs
@@ -9,13 +9,7 @@ namespace Active.Core{
 public abstract partial class AbstractDecorator : IDecorator,
                                                   Resettable{
 
-    internal virtual float time{ get{
-      #if UNITY_2018_1_OR_NEWER
-        return UnityEngine.Time.time;
-      #else
-        return System.DateTime.Now.Millisecond/1000f;
-      #endif
-    }}
+    internal float time => SimTime.time;
 
     protected static int ID(int id) => id == 0 ? ++MaxId : id;
 

--- a/Src/Stateful/Task.cs
+++ b/Src/Stateful/Task.cs
@@ -39,17 +39,13 @@ public abstract partial class Task : Gig, Context {
 
     public virtual action Reset(){
         if(_context != null) foreach(var k in _context) k.Reset();
-      #if !AL_BEST_PERF
         _store?.Reset();
-      #endif
         return @void();
     }
 
     public virtual action Release(){
         _context = null;
-      #if !AL_BEST_PERF
-        _store = null;
-      #endif
+        _store   = null;
         return Reset();
     }
 

--- a/Src/Static/ActiveRaw.cs
+++ b/Src/Static/ActiveRaw.cs
@@ -21,16 +21,9 @@ public static class Raw{
 
     public static status Eval(status s) => s;
 
-    #if AL_OPTIMIZE
-    //public static status undef      => throw new Unimplemented();
-    //public static status undef_done => throw new Unimplemented();
-    //public static status undef_cont => throw new Unimplemented();
-    //public static status undef_fail => throw new Unimplemented();
-    #else
-    public static status undef      = status._fail;
-    public static status undef_done = status._done;
-    public static status undef_cont = status._cont;
-    public static status undef_fail = status._fail;
+    #if !AL_OPTIMIZE
+    public static status undef()         => status._fail;
+    public static status undef(status s) => s;
     #endif
 
     public static action  Do   (object arg) => @void;

--- a/Tests/Decorators/AbstractDecoratorTest.cs
+++ b/Tests/Decorators/AbstractDecoratorTest.cs
@@ -6,7 +6,10 @@ using static Active.Status;
 public class AbstractDecoratorTest
              : DecoratorTest<AbstractDecoratorTest.C>{
 
-    [Test] public void Time() => o( x.GetTime() != 0 );
+    [Test] public void Time(){
+        SimTime.time = 10f;
+        o( x.GetTime(), 10f );
+    }
 
     public class C : AbstractDecorator{
         public C(){}

--- a/Tests/Decorators/TestCooldown.cs
+++ b/Tests/Decorators/TestCooldown.cs
@@ -92,15 +92,10 @@ public class TestCooldown : DecoratorTest<TestCooldown.Cooldown> {
   #endif
 
 	public class Cooldown : Active.Core.Cooldown{
-		public int time_;
 		public Cooldown() : base(){}
 		public Cooldown(float duration) : base(duration){}
-		override internal float time => time_;
 	}
 
-	int t{
-		set => x.time_ = value;
-		get => x.time_;
-	}
+	int t{ set => SimTime.time = value; }
 
 }

--- a/Tests/Decorators/TestInterval.cs
+++ b/Tests/Decorators/TestInterval.cs
@@ -10,7 +10,7 @@ public class TestInterval : DecoratorTest<TestInterval.Interval> {
 
 	bool _log;
 
-	static float t; // Time.time value for testing
+	static float t{ set => SimTime.time = value; }
 
 	[SetUp] override public void Setup(){
 		t = 0;
@@ -132,7 +132,6 @@ public class TestInterval : DecoratorTest<TestInterval.Interval> {
 		public Interval() : base(){}
 		public Interval(float period, float offset=0f)
 	    : base(period, offset){}
-		override internal float time => TestInterval.t;
 	}
 
 }

--- a/Tests/Decorators/TestTimeout.cs
+++ b/Tests/Decorators/TestTimeout.cs
@@ -5,7 +5,7 @@ using Active.Core;
 /* Timeout limits the duration of the target task */
 public class TestTimeout : DecoratorTest<TestTimeout.Timeout> {
 
-	static float t;  // Replaces Time.time (see derived class at end)
+	static float t{ set => SimTime.time = value; }
 
 	[SetUp] override public void Setup(){ t = 0; base.Setup(); }
 
@@ -66,10 +66,8 @@ public class TestTimeout : DecoratorTest<TestTimeout.Timeout> {
 	}
 
 	public class Timeout : Active.Core.Timeout{
-		public float time_ => TestTimeout.t;
 		public Timeout() : base(){}
 		public Timeout(float duration) : base(duration){}
-		override internal float time => time_;
 	}
 
 }

--- a/Tests/TestActiveRaw.cs
+++ b/Tests/TestActiveRaw.cs
@@ -27,10 +27,10 @@ public class TestActiveRaw : TestBase{
 
     #if !AL_OPTIMIZE
     [Test] public void Undef(){
-        o( undef.failing );
-        o( undef_done.complete );
-        o( undef_cont.running );
-        o( undef_fail.failing );
+        o( undef().failing );
+        o( undef(done).complete );
+        o( undef(cont).running );
+        o( undef(fail).failing );
     }
     #endif
 

--- a/Tests/TestStatusRef.cs
+++ b/Tests/TestStatusRef.cs
@@ -48,9 +48,12 @@ public class TestStatusRef : TestBase{
         StatusRef.ToStatusWithLog(x);
     }
 
-    [Test] public void ToStatusWithLog_badScope(){
+    [Test] public void ToStatusWithLog_badScope([Values(true, false)] bool lg){
+        status.log = lg;
         StatusRef.SetLogData(null, null, null);
-        Assert.Throws<InvOp>( () => StatusRef.ToStatusWithLog(null) );
+        if(status.log)
+            Assert.Throws<InvOp>(
+                () => StatusRef.ToStatusWithLog(null) );
     }
 
     [Test] public void ToStatusWithLog_nullRef([Values(true, false)]

--- a/Tests/tests.csproj
+++ b/Tests/tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Sim time allows the user to provide their own time value before running BTs; this removes defaulting to system time (API breaking change; however, prior implementation was buggy anyway).
- Removed AL_BEST_PERF support; this flag did not bring any performance improvements and its only purpose was to fence slower APIs. Overall this feature is expensive to maintain, and may not promote sound workflows.
- Fix #76
- Fix a logging related issue
- Fix raw forms of `undef`
- Stepping a null task now returns `fail` (instead of raising)
